### PR TITLE
Refresh CSRF Token when using Turbolinks

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -111,6 +111,7 @@
 //= require budget_hide_money
 //= require datepicker
 //= require link_to_top
+//= require authenticity_token_refresh
 //= require_tree ./admin
 //= require_tree ./sdg
 //= require_tree ./sdg_management
@@ -172,6 +173,7 @@ var initialize_modules = function() {
   App.LinkToTop.initialize();
   App.SDGRelatedListSelector.initialize();
   App.SDGManagementRelationSearch.initialize();
+  App.AuthenticityTokenRefresh.initialize();
 };
 
 var destroy_non_idempotent_modules = function() {

--- a/app/assets/javascripts/authenticity_token_refresh.js
+++ b/app/assets/javascripts/authenticity_token_refresh.js
@@ -1,0 +1,8 @@
+(function() {
+  "use strict";
+  App.AuthenticityTokenRefresh = {
+    initialize: function() {
+      $.rails.refreshCSRFTokens();
+    }
+  };
+}).call(this);


### PR DESCRIPTION
## Objectives

Avoid the following error when using Turbolinks
```
Can't verify CSRF token authenticity.
Completed 422 Unprocessable Entity
ActionController::InvalidAuthenticityToken (ActionController::InvalidAuthenticityToken)
```