### PR TITLE
Custom management investments

### DIFF
--- a/app/controllers/management/budgets/investments_controller.rb
+++ b/app/controllers/management/budgets/investments_controller.rb
@@ -45,7 +45,7 @@ class Management::Budgets::InvestmentsController < Management::BaseController
   end
 
   def print
-    @investments = @investments.apply_filters_and_search(@budget, params).order(cached_votes_up: :desc).for_render.limit(15)
+    @investments = @investments.apply_filters_and_search(@budget, params).order(cached_votes_up: :desc).for_render
   end
 
   private

--- a/app/views/custom/budgets/investments/_management_investment.html.erb
+++ b/app/views/custom/budgets/investments/_management_investment.html.erb
@@ -1,0 +1,77 @@
+<div id="<%= dom_id(investment) %>" class="budget-investment clear">
+  <div class="panel
+              <%= "with-image" if feature?(:allow_images) && investment.image.present? %>
+              <%= "supported" if current_user&.voted_for?(investment) %>">
+    <% if feature?(:allow_images) && investment.image.present? %>
+    <div class="row">
+
+      <div class="small-12 medium-3 large-2 column text-center">
+        <%= link_to namespaced_budget_investment_path(investment), id: "image" do %>
+          <%= image_tag investment.image.variant(:thumb), alt: investment.image.title.unicode_normalize %>
+        <% end %>
+      </div>
+
+      <div class="small-12 medium-6 large-7 column">
+    <% else %>
+      <div class="row">
+        <div class="small-12 medium-9 column">
+    <% end %>
+        <div class="budget-investment-content">
+
+          <% cache [locale_and_user_status(investment), "index", investment, investment.author] do %>
+            <h3>
+              <%= investment.id %><br>
+              <%= link_to investment.title, namespaced_budget_investment_path(investment) %>
+            </h3>
+
+            <%= render Budgets::Investments::InfoComponent.new(investment) %>
+
+            <div class="investment-project-description">
+              <%= wysiwyg(investment.description) %>
+              <div class="truncate"></div>
+            </div>
+            <%= render "shared/tags", taggable: investment, limit: 5 %>
+          <% end %>
+        </div>
+      </div>
+
+      <% unless investment.unfeasible? %>
+
+        <% if investment.should_show_votes? %>
+          <div id="<%= dom_id(investment) %>_votes"
+               class="small-12 medium-3 column text-center"
+               <%= "data-equalizer-watch" if feature?(:allow_images) && investment.image.present? %>>
+               <%= render Budgets::Investments::VotesComponent.new(investment) %>
+          </div>
+        <% elsif investment.should_show_vote_count? %>
+          <div id="<%= dom_id(investment) %>_votes"
+               class="small-12 medium-3 column text-center">
+            <div class="supports">
+              <span class="total-supports no-button">
+                <%= t("budgets.investments.investment.supports",
+                    count: investment.total_votes) %>
+              </span>
+            </div>
+          </div>
+        <% elsif investment.should_show_ballots? && !management_controller? %>
+          <div id="<%= dom_id(investment) %>_ballot"
+               class="small-12 medium-3 column text-center">
+                <%= render "/budgets/investments/ballot",
+                  investment: investment,
+                  investment_ids: investment_ids,
+                  ballot: ballot %>
+          </div>
+        <% elsif investment.should_show_price? %>
+          <div id="<%= dom_id(investment) %>_price"
+               class="supports small-12 medium-3 column text-center">
+            <div class="supports">
+              <span class="total-supports no-button">
+                <%= investment.formatted_price %>
+              </span>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/management/budgets/investments/print.html.erb
+++ b/app/views/management/budgets/investments/print.html.erb
@@ -23,7 +23,7 @@
       </div>
 
       <% @investments.each do |investment| %>
-        <%= render "/budgets/investments/investment",
+        <%= render "/budgets/investments/management_investment",
           investment: investment,
           investment_ids: @investment_ids,
           ballot: @ballot %>

--- a/spec/system/custom/management/budget_investments_spec.rb
+++ b/spec/system/custom/management/budget_investments_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe "Budget Investments" do
+  let(:manager) { create(:manager) }
+  let(:budget)  { create(:budget, :selecting, name: "2033", slug: "budget_slug") }
+  let(:group)   { create(:budget_group, budget: budget, name: "Whole city") }
+  let(:heading) { create(:budget_heading, group: group, name: "Health") }
+
+  context "Printing" do
+    scenario "Printing budget investments is not limited to 15" do
+      20.times { create(:budget_investment, heading: heading) }
+
+      login_as_manager(manager)
+      click_link "Print budget investments"
+
+      expect(page).to have_content(budget.name)
+      within "#budget_#{budget.id}" do
+        click_link "Print budget investments"
+      end
+
+      expect(page).to have_css(".budget-investment", count: 20)
+      expect(page).to have_link("Print", href: "javascript:window.print();")
+    end
+
+    scenario "Printing budget investments show investment id" do
+      investment = create(:budget_investment, heading: heading)
+
+      login_as_manager(manager)
+      click_link "Print budget investments"
+
+      expect(page).to have_content(budget.name)
+      within "#budget_#{budget.id}" do
+        click_link "Print budget investments"
+      end
+
+      expect(page).to have_content(investment.id)
+    end
+  end
+end

--- a/spec/system/management/budget_investments_spec.rb
+++ b/spec/system/management/budget_investments_spec.rb
@@ -454,7 +454,7 @@ describe "Budget Investments" do
       expect(page).to have_content("Children")
     end
 
-    scenario "Printing budget investments" do
+    scenario "Printing budget investments", :consul do
       16.times { create(:budget_investment, heading: heading) }
 
       login_as_manager(manager)


### PR DESCRIPTION
## Objectives

Custom management investments:
- Remove limit of 15 investments and show all on the management print list.
- Add Investment ID on the management print list.

